### PR TITLE
[Monster Parts] Check for Mutant Couture skills

### DIFF
--- a/RELEASE/scripts/excavator/projects/x_monster_parts.ash
+++ b/RELEASE/scripts/excavator/projects/x_monster_parts.ash
@@ -104,6 +104,18 @@ void spade_monster_parts( string encounter, string page )
     {
         check_and_report( mon, "arm", confirmation );
     }
+
+    if ( current_round() == 1 && is_wearing_outfit( "Mutant Couture" ) )
+    {
+        string skills = page.excise( "<select name=whichskill>", "</select>" );
+
+        if ( skills != "" )
+        {
+            check_and_report( mon, "head", skills.contains_text( `<option value="{$skill[Strangle].to_int()}"` ) );
+            check_and_report( mon, "arm", skills.contains_text( `<option value="{$skill[Disarm].to_int()}"` ) );
+            check_and_report( mon, "leg", skills.contains_text( `<option value="{$skill[Entangle].to_int()}"` ) );
+        }
+    }
 }
 
 register_project( "COMBAT_ROUND", "spade_monster_parts" );


### PR DESCRIPTION
Mafia just tells me I have the outfit skills whenever I'm wearing it, so I can't rely on `has_skill`. I think there's a way to hide the skills select and just use the top bar? But this will just degrade gracefully in that instance.