### PR TITLE
Include current difficulty in coat-a-day excavation

### DIFF
--- a/RELEASE/scripts/excavator/projects/x_coat_of_paint.ash
+++ b/RELEASE/scripts/excavator/projects/x_coat_of_paint.ash
@@ -25,7 +25,6 @@ string [string] get_paint_modifiers( string page )
         if ( COAT_OF_PAINT.numeric_modifier( key ) != 0 )
         {
             data[ type ] = key;
-            data[ `{type}_value` ] = COAT_OF_PAINT.numeric_modifier( key ).to_string();
         }
     }
 
@@ -50,7 +49,7 @@ void spade_coat_of_paint( string item_name, string page )
         return;
     }
 
-    string [string] data = combine_maps( get_paint_modifiers( page ), get_day_seed() );
+    string [string] data = combine_maps( get_paint_modifiers( page ), get_day_seed(), get_difficulty_seed() );
     send_spading_data( data, "Fresh Coat Of Paint" );
 }
 

--- a/RELEASE/scripts/excavator/x_utils.ash
+++ b/RELEASE/scripts/excavator/x_utils.ash
@@ -65,6 +65,19 @@ string [string] get_gameday_seed()
     return seed;
 }
 
+string [string] get_difficulty_seed()
+{
+    string difficulty = "Casual";
+    if ( my_path_id() != 0 ) { difficulty = "Normal"; }
+    if ( !can_interact() ) { difficulty = "Normal (Ronin)"; }
+    if ( in_hardcore() ) { difficulty = "Hardcore"; }
+    string [string] seed = {
+        "difficulty": difficulty,
+    };
+
+    return seed;
+}
+
 string to_normalised_string( monster mon )
 {
     return `[{mon.to_int()}]{mon.to_string()}`;


### PR DESCRIPTION
- Removes value tracking from Fresh Coat of Paint excavation- we know it's always +5 stats, +2 resist, +20 damage, so this seems superfluous
- As evidence is suggesting that difficulty (Hardcore, Normal, Casual) affects seeding for the Fresh Coat of Paint, a `get_difficulty_seed()` function has been added, and incorporated into its reported values.

KNOWN ISSUE: This method cannot distinguish between an unrestricted normalcore ascension that has broken ronin and a casual ascension that has spent more than 1000 turns. This seems sufficiently niche a case that it shouldn't be a dealbreaker, and there doesn't appear to be a presently exposed way to determine the difference, but it is still unfortunate