### PR TITLE
feat: return git version if svn version is 0

### DIFF
--- a/RELEASE/scripts/excavator.ash
+++ b/RELEASE/scripts/excavator.ash
@@ -1,4 +1,4 @@
-since r20180; // CONSUME_* events now triggered after mafia's result processing
+since r26571; // git_info function
 
 import <excavator/x_utils.ash>;
 

--- a/RELEASE/scripts/excavator/x_utils.ash
+++ b/RELEASE/scripts/excavator/x_utils.ash
@@ -13,6 +13,10 @@ string get_excavator_revision()
     {
         revision = svn_info("Excavator").revision;
     }
+    if ( revision == 0 )
+    {
+        revision = git_info("gausie-excavator").commit.substring(0, 7);
+    }
 
     return revision;
 }

--- a/RELEASE/scripts/excavator/x_utils.ash
+++ b/RELEASE/scripts/excavator/x_utils.ash
@@ -15,7 +15,8 @@ string get_excavator_revision()
     }
     if ( revision == 0 )
     {
-        revision = git_info("gausie-excavator").commit.substring(0, 7);
+        string rev = git_info("gausie-excavator").commit.substring(0, 7);
+        if (rev != "") return rev;
     }
 
     return revision;


### PR DESCRIPTION
Some users, as seen in the spreadsheet, appear to have installed this through Git, as the version is zero.

Try to return something meaningful in that case.

Increment Mafia version accordingly.