### PR TITLE
feat: stop supporting SVN installs as these are impossible

### DIFF
--- a/packages/excavator-script/src/utils/spading.ts
+++ b/packages/excavator-script/src/utils/spading.ts
@@ -8,7 +8,6 @@ import {
   inMultiFight,
   print,
   printHtml,
-  svnInfo,
 } from "kolmafia";
 import { get, Kmail, set } from "libram";
 
@@ -18,12 +17,7 @@ const DATA_PROPERTY = "spadingData";
 const RECIPIENT_PROPERTY = "excavatorRecipient";
 
 function getExcavatorVersion() {
-  return (
-    svnInfo("gausie-excavator-trunk-RELEASE").revision ||
-    svnInfo("Excavator").revision ||
-    gitInfo("gausie-excavator").commit.substring(0, 7) ||
-    0
-  );
+  return gitInfo("gausie-excavator-release").commit.substring(0, 7) || 0;
 }
 
 function getVersionString() {


### PR DESCRIPTION
Also explicitly refer to `gausie-excavator-release` instead of a substring.