### PR TITLE
fix: fix install using the main branch

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,1 @@
+github gausie/excavator release


### PR DESCRIPTION
Historically, installs were using the default branch. If someone updates their existing install, nothing will be installed or updated. Set the new script as a dependency so it gets automatically installed.